### PR TITLE
Add implementation roadmap for modernization plan

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,0 +1,61 @@
+# Plan de implementación para modernización
+
+Este documento detalla las actividades, responsables y entregables necesarios para materializar el plan estratégico descrito en la auditoría técnica. Se estructura en fases iterativas de dos semanas, con seguimiento semanal y métricas de finalización por historia.
+
+## Fase 0 · Preparación (Semana 0)
+- **Inventario de activos**: catalogar datasets, modelos y claves API existentes. Documentar responsables y restricciones de uso.
+- **Configuración base**: habilitar entorno reproducible con `pyenv`/`poetry`, plantillas de `pre-commit` y un pipeline CI temporal que ejecute lint y pruebas existentes.
+- **Definición de KPIs**: acordar métricas de éxito (tiempo de respuesta del backend, cobertura de pruebas, latencia de UI, satisfacción de usuarios piloto).
+
+## Fase 1 · Consolidación del dominio (Semanas 1-2)
+- **Refactorización a servicios**:
+  - Extraer lógica de negocio de páginas Streamlit hacia un paquete `src/services/`.
+  - Crear contratos de entrada/salida con `pydantic` y documentarlos en docstrings.
+- **Cobertura de pruebas**:
+  - Diseñar casos sintéticos para estimaciones ML y validaciones de waveform.
+  - Integrar `pytest-cov` y fijar un objetivo inicial del 70% de cobertura en servicios.
+- **Entregables**: módulo `services`, informes de cobertura, manual de migración para desarrolladores.
+
+## Fase 2 · API HTTP y seguridad (Semanas 3-4)
+- **FastAPI**:
+  - Montar aplicación en `src/api` con routers separados para ingestión, análisis, agentes y reporting.
+  - Implementar esquemas OpenAPI con ejemplos y pruebas de contrato usando `schemathesis`.
+- **Autenticación y control de acceso**:
+  - Añadir autenticación Bearer con JWT, almacenamiento de claves en `pydantic-settings` y rotación programada.
+  - Definir límites de tasa con `slowapi` y políticas para llamadas a modelos externos.
+- **Entregables**: servidor FastAPI dockerizado, documentación interactiva, pruebas de contrato automatizadas.
+
+## Fase 3 · Infraestructura y DevOps (Semanas 5-6)
+- **Configuración unificada**:
+  - Desacoplar dependencias en `requirements/{base,dev,prod}.txt` y soportar variables `.env` cifradas.
+  - Instrumentar logging estructurado y métricas (Prometheus + Grafana).
+- **CI/CD**:
+  - Crear pipelines en GitHub Actions para lint, pruebas, build y publicación de imágenes.
+  - Definir despliegue en Docker Compose y plantilla Helm para entornos gestionados.
+- **Entregables**: archivos de requisitos segmentados, dashboards de monitoreo, pipelines activos.
+
+## Fase 4 · Frontend moderno (Semanas 7-10)
+- **Bootstrapping**:
+  - Seleccionar stack (Next.js + TypeScript recomendado) y configurar monorepo con `pnpm` o `turborepo`.
+  - Integrar diseño base con Storybook y sistema de componentes accesible.
+- **Integración con backend**:
+  - Implementar clientes API tipados con `openapi-typescript`.
+  - Desarrollar vistas para ingestión, visualización de waveforms, histogramas y agente IA con chat contextual.
+- **Garantía de calidad**:
+  - Añadir pruebas E2E con Playwright y pruebas de accesibilidad con `axe-core`.
+- **Entregables**: repositorio frontend independiente, historias de usuario completas, suite E2E en CI.
+
+## Fase 5 · Migración y soporte (Semanas 11-12)
+- **Transición controlada**:
+  - Ejecutar pruebas de regresión comparando respuestas Streamlit vs API.
+  - Configurar feature flags para activar la nueva UI gradualmente.
+- **Documentación y capacitación**:
+  - Actualizar README, guías de despliegue y capacitación para soporte nivel 1.
+  - Formalizar acuerdos de nivel de servicio (SLA) y plan de respuesta a incidentes.
+- **Entregables**: reporte de regresión, manuales actualizados, aceptación de stakeholders.
+
+## Gobernanza continua
+- Revisión quincenal de backlog y KPIs.
+- Auditorías trimestrales de seguridad y privacidad.
+- Roadmap de evolución del modelo IA alineado con feedback de usuarios.
+

--- a/docs/repository_review.md
+++ b/docs/repository_review.md
@@ -1,0 +1,43 @@
+# Auditoría técnica y plan de modernización
+
+## Fortalezas principales
+- **Cobertura funcional rica y documentada**: el README resume claramente capacidades clave (ingesta multi-formato, visualización interactiva, agentes IA) y la estructura de carpetas, facilitando la incorporación de nuevos contribuidores.
+- **Núcleo modular y reutilizable**: componentes como `DataReader`, `MagnitudeResult` y los estimadores ML están aislados en `src/core`, con dataclasses y utilidades específicas que simplifican su reutilización en otros entornos.
+- **Pruebas unitarias enfocadas**: existen pruebas para los módulos críticos (lectura de datos, metadatos Kelunji, utilidades ObsPy), lo que proporciona una base inicial para validar regresiones.
+- **Utilidades compartidas maduras**: `src/utils/logger.py` y `src/streamlit_utils/**` centralizan manejo de estado, carga de archivos y componentes UI, reduciendo duplicaciones.
+
+## Debilidades y riesgos
+- **Acoplamiento UI-lógica**: las páginas Streamlit invocan directamente lógica de dominio y mutan el estado global, lo que complica la reutilización desde otro cliente.
+- **Ausencia de API formal**: toda interacción ocurre dentro de Streamlit; no hay endpoints REST/GraphQL ni capa de servicios que expongan cálculos a clientes externos.
+- **Dependencias mixtas sin aislamiento**: `requirements.txt` mezcla dependencias de producción y herramientas de desarrollo/packaging, dificultando builds mínimos.
+- **Pruebas incompletas**: no se cubren flujos de AI Agent, histogramas ni localización; además, varias pruebas están condicionadas por la presencia de ObsPy, lo que puede ocultar fallos en CI.
+- **Distribución y CI pendientes**: no hay pipelines declarados ni artefactos de despliegue; la licencia está marcada como “pendiente”.
+
+## Plan propuesto: frontend web dedicado con backend Python
+
+### 1. Consolidar la capa de dominio Python (Semana 1)
+- Extraer servicios puros desde `src/core` y `src/ai_agent` en un paquete `src/services`, con funciones sin dependencias de Streamlit.
+- Definir modelos de entrada/salida con `pydantic` para lecturas, picks, histogramas y resultados ML.
+- Añadir pruebas adicionales que cubran los nuevos servicios y las rutas críticas (e.g. estimaciones ML con datasets sintéticos).
+
+### 2. Diseñar API HTTP (Semana 2)
+- Crear un backend `FastAPI` dentro de `src/api`, orquestando servicios para operaciones de carga, análisis, agentes IA y generación de reportes.
+- Implementar autenticación básica (token/bearer) y límites de tasa para llamadas a modelos externos.
+- Documentar la API con OpenAPI/Swagger y ejemplos de uso.
+
+### 3. Configurar infraestructura compartida (Semana 3)
+- Unificar configuración en `.env` gestionada por `pydantic-settings`, incluyendo llaves IA, rutas de datos y parámetros de telemetría.
+- Desacoplar dependencias de desarrollo creando `requirements/base.txt`, `requirements/dev.txt` y `requirements/prod.txt`.
+- Incorporar Docker multi-stage para backend + worker de IA, y definir pipelines CI (lint, pruebas, build de imagen).
+
+### 4. Desarrollar frontend moderno (Semanas 4–6)
+- Bootstrapping con Next.js + TypeScript o Vite + React, integrando componentes de gráficos (e.g. Plotly.js, ECharts).
+- Consumir la API para carga de archivos (pre-signed URLs), renderizado de waveforms y dashboards de histogramas.
+- Implementar vistas equivalentes a las páginas actuales (Uploader, Waveform Viewer, Histogramas, Location) y un panel dedicado al agente IA con chat contextual.
+- Añadir internacionalización (es/en) y control de sesiones (JWT + refresh tokens) alineado con el backend.
+
+### 5. Migración gradual y soporte (Semanas 7–8)
+- Ejecutar pruebas de regresión comparando resultados del backend vía scripts automatizados.
+- Mantener Streamlit como fallback durante la transición, con banderas para redirigir a la nueva UI.
+- Documentar guías de despliegue (Docker Compose, Kubernetes) y actualizar README/licencia.
+


### PR DESCRIPTION
## Summary
- add a written technical audit capturing strengths and risks of the current codebase
- outline a phased plan to build a dedicated web frontend while preserving the Python backend
- create an implementation roadmap with concrete activities, deliverables, and timelines for the modernization effort

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d91febf69c832388fe0700a38d49ec